### PR TITLE
feat: support specifying the size of windows

### DIFF
--- a/docs/reference/sway_out.utils.md
+++ b/docs/reference/sway_out.utils.md
@@ -1,0 +1,1 @@
+::: sway_out.utils

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,3 +37,4 @@ nav:
     - sway_out.marks: reference/sway_out.marks.md
     - sway_out.matching: reference/sway_out.matching.md
     - sway_out.notifications: reference/sway_out.notifications.md
+    - sway_out.utils: reference/sway_out.utils.md

--- a/src/sway_out/__init__.py
+++ b/src/sway_out/__init__.py
@@ -7,6 +7,7 @@ from . import (
     marks,
     matching,
     notifications,
+    utils,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "marks",
     "matching",
     "notifications",
+    "utils",
 ]

--- a/src/sway_out/layout.py
+++ b/src/sway_out/layout.py
@@ -2,12 +2,13 @@
 
 import itertools
 import logging
+from typing import Literal
 
 from i3ipc import Con, Connection
 
 from .connection import find_cons_by_id, run_command_on
 from .layout_files import ApplicationLaunchConfig, ContainerConfig, WorkspaceLayout
-from .matching import is_window_matching
+from .utils import get_con_description
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +16,17 @@ MARK = "@"
 """The layouting algorithm requires a mark to move windows around.
 
 This should be something that is not in use otherwise.
+"""
+
+RESIZE_ATTEMPTS = 5
+"""Number of attempts to resize a container to the expected size."""
+
+RESIZE_TOLERANCE_PERCENT = 1
+"""The tolerance in percent for resizing a container.
+
+Because the parent container size might not always be exactly divisible by the
+ratio of the children, we allow a small tolerance so that the layout can still be
+applied.
 """
 
 
@@ -36,18 +48,6 @@ def create_layout(
     Note: This function modifies its argument.
     """
 
-    def find_con_for_application(container: ApplicationLaunchConfig) -> Con:
-        con_id = container._con_id
-        assert con_id is not None, (
-            f"Application {container} has no con_id set. "
-            + "This is required for the layout creation."
-        )
-        result = connection.get_tree().find_by_id(con_id)
-        assert (
-            result is not None
-        ), f"Container for application with con ID {con_id} not found"
-        return result
-
     def find_parent_con(con_id: int) -> Con:
         tree = connection.get_tree()
         for con in tree.descendants():
@@ -61,12 +61,14 @@ def create_layout(
         (con,) = find_cons_by_id(connection, con_id)
         if con.workspace().id != workspace_id:
             logger.debug(
-                f"Moving container {con.name} ({con.id}) to workspace {workspace_con.name}"
+                f"Moving container {get_con_description(con)} to workspace {get_con_description(workspace_con)}"
             )
-            run_command_on(con, f"move container to workspace {workspace_con.name}")
+            run_command_on(
+                con, f"move container to workspace {get_con_description(workspace_con)}"
+            )
         else:
             logger.debug(
-                f"Container {con.name} ({con.id}) is already on workspace {workspace_con.name}"
+                f"Container {get_con_description(con)} is already on workspace {get_con_description(workspace_con)}"
             )
 
         # Make sure that the con is a direct child of the workspace to make layouting less error-prone.
@@ -76,21 +78,21 @@ def create_layout(
             # Make shure that the container is still on the workspace.
             (con,) = find_cons_by_id(connection, con_id)
             assert con.workspace().id == workspace_id, (
-                f"Accidentally moved {con.name} ({con.id}) to another workspace "
-                + f"({con.workspace().name} ({con.workspace().id}) "
-                + f"instead of {workspace_con.name} ({workspace_id}))"
+                f"Accidentally moved {get_con_description(con)} to another workspace "
+                + f"({get_con_description(con.workspace())} "
+                + f"instead of {get_con_description(workspace_con)})"
             )
 
     def swap_cons(con_id: int, target_id: int):
         (con, target_con) = find_cons_by_id(connection, con_id, target_id)
         if target_id != con_id:
             logger.debug(
-                f"Swapping container {con.name} ({con.id}) with {target_con.name} ({target_con.id}) "
-                + f"to position {index} on workspace {workspace_con.name}"
+                f"Swapping container {get_con_description(con)} with {get_con_description(target_con)} "
+                + f"to position {index} on workspace {get_con_description(workspace_con)}"
             )
             run_command_on(con, f"swap container with con_id {target_con.id}")
         else:
-            logger.debug(f"Container {con.name} ({con.id}) is already in position")
+            logger.debug(f"Container {get_con_description(con)} is already in position")
 
     def move_con_into(con_id: int, target_id: int):
         # There does not seem to be a way to move a con to an arbitrary position in a layout.
@@ -137,7 +139,9 @@ def create_layout(
                 )
 
                 # Swap the child to the correct position if needed.
-                (layout_con,) = find_cons_by_id(connection, layout_id)
+                (layout_con, child_con) = find_cons_by_id(
+                    connection, layout_id, child_id
+                )
                 assert len(layout_con.nodes) >= index + 1, (
                     f"After moving the child, there should be at least {index + 1} windows on the layout, "
                     + "but found {len(layout_con.nodes)}"
@@ -151,7 +155,8 @@ def create_layout(
         else:
             # Nothing to lay out here.
             assert isinstance(container_layout, ApplicationLaunchConfig)
-            result = find_con_for_application(container_layout)
+            tree = connection.get_tree()
+            result = _find_con(tree, container_layout)
             logger.debug(f'Reached leaf "{result.name}" while creating layout')
             layouted_ids.add(result.id)
             return result.id
@@ -171,17 +176,19 @@ def create_layout(
     (workspace_con,) = find_cons_by_id(connection, workspace_id)
     assert (
         workspace_con.nodes
-    ), f"The workspace {workspace_con.name} should not be empty at this point"
+    ), f"The workspace {get_con_description(workspace_con)} should not be empty at this point"
     run_command_on(workspace_con.nodes[0], "layout splith")
     for index, child_layout in enumerate(workspace_layout.children):
-        logger.debug(f"Creating layout for workspace {workspace_con.name} ...")
+        logger.debug(
+            f"Creating layout for workspace {get_con_description(workspace_con)} ..."
+        )
         child_id = create_container_layout(child_layout)
 
         # Ensure that the child is on the right workspace.
         move_con_to_workspace(child_id)
 
         # Because we start at index == 0, there should now be at least index+1 windows on the workspace.
-        (workspace_con,) = find_cons_by_id(connection, workspace_id)
+        (workspace_con, child_con) = find_cons_by_id(connection, workspace_id, child_id)
         assert len(workspace_con.nodes) >= index + 1
 
         # Swap the child to the correct position if needed.
@@ -190,14 +197,14 @@ def create_layout(
 
     assert (
         workspace_con.nodes
-    ), f"The workspace {workspace_con.name} should not be empty at this point"
+    ), f"The workspace {get_con_description(workspace_con)} should not be empty at this point"
     if workspace_layout.layout is not None:
         # Set the layout of the workspace to the one specified in the layout.
         logger.debug(
-            f"Setting layout of workspace {workspace_con.name} to {workspace_layout.layout}"
+            f"Setting layout of workspace {get_con_description(workspace_con)} to {workspace_layout.layout}"
         )
         run_command_on(workspace_con.nodes[0], f"layout {workspace_layout.layout}")
-    logger.info(f"Layout for workspace {workspace_con.name} done")
+    logger.info(f"Layout for workspace {get_con_description(workspace_con)} done")
     layouted_ids.add(workspace_id)
 
     # The mark should be freed up after the layout is created.
@@ -206,8 +213,286 @@ def create_layout(
         MARK not in marks_in_use
     ), f"The mark '{MARK}' was not removed after layout creation."
 
-    # Look for windows that are not part of the layout.
-    (workspace_con,) = find_cons_by_id(connection, workspace_id)
-    for con in workspace_con.descendants():
-        if con.id not in layouted_ids:
-            logger.warning(f"Container {con.name} ({con.id}) is not part of the layout")
+
+def find_leftover_windows(
+    connection: Connection, workspace_layout: WorkspaceLayout
+) -> list[Con]:
+    """Finds windows that are not part of the given workspace layout.
+
+    Parameters:
+        connection: A connection to sway.
+        workspace_layout: The layout to check against.
+
+    Returns:
+        A list of windows that are not part of the layout.
+    """
+
+    def remove_matched_windows(
+        con_layout: WorkspaceLayout | ContainerConfig | ApplicationLaunchConfig,
+    ):
+        if isinstance(con_layout, ApplicationLaunchConfig):
+            assert (
+                con_layout._con_id is not None
+            ), "The con_id of the application launch config should have been set before calling this function."
+            if con_layout._con_id in leftover_windows:
+                del leftover_windows[con_layout._con_id]
+            else:
+                logger.warning(
+                    f"Application {con_layout.name} with con_id {con_layout._con_id} not found while "
+                    + "looking for leftover windows."
+                )
+        else:
+            for child in con_layout.children:
+                remove_matched_windows(child)
+
+    tree = connection.get_tree()
+    workspace_id = workspace_layout._con_id
+    leftover_windows = {
+        con.id: con for con in tree.leaves() if con.workspace().id == workspace_id
+    }
+    remove_matched_windows(workspace_layout)
+    return leftover_windows.values()
+
+
+def resize_layout(
+    connection: Connection,
+    workspace_layout: WorkspaceLayout,
+) -> None:
+    """Resizes the containers on the workspace so that they match the given layout.
+
+
+    Parameters:
+        connection: A connection to sway.
+        workspace_layout: The layout to apply.
+    """
+
+    def resize_children(con_layout: WorkspaceLayout | ContainerConfig):
+        con = _find_con(tree, con_layout)
+
+        con_width_px, con_height_px = _get_container_size_excluding_gaps(con)
+
+        if con_layout.layout in ["splith", "splitv"]:
+            layout = con_layout.layout
+        else:
+            layout = "other"
+
+        # Give up after a few attempts to avoid infinite loops.
+        for i in range(RESIZE_ATTEMPTS):
+            logger.debug(
+                f"Resizing container {get_con_description(con)} to {con_width_px}px x {con_height_px}px "
+                + f"(attempt {i + 1}/{RESIZE_ATTEMPTS})"
+            )
+            retry = False
+            for child in con_layout.children:
+                if not resize_con(child, con_width_px, con_height_px, layout):
+                    retry = True
+            if not retry:
+                logger.debug(
+                    f"Container {get_con_description(con)} resized successfully after "
+                    + f"{i+1}/{RESIZE_ATTEMPTS} attempts."
+                )
+                break
+        else:
+            logger.error(
+                f"Failed to resize container {get_con_description(con)} to {con_width_px}px x {con_height_px}px "
+                + f"after {RESIZE_ATTEMPTS} attempts."
+            )
+
+    def resize_con(
+        con_layout: ApplicationLaunchConfig | ContainerConfig,
+        parent_width_px: int,
+        parent_height_px: int,
+        parent_layout: Literal["splith", "splitv", "other"],
+    ) -> bool:
+        con = _find_con(tree, con_layout)
+
+        result = True
+        if con_layout.percent is not None:
+            assert parent_layout != "other", (
+                "Percentages are only supported for horizontal and vertical splits, not for other layouts."
+                + "This should have been enforced by the configuration models."
+            )
+            if parent_layout == "splith":
+                expected_width_px = parent_width_px * con_layout.percent // 100
+                run_command_on(con, f"resize set width {expected_width_px} px")
+                actual_width_px = con.rect.width
+                tolerance_px = expected_width_px * RESIZE_TOLERANCE_PERCENT // 100
+                logger.debug(
+                    f"Expected width: {expected_width_px}px, actual width: {actual_width_px}px, "
+                    + f"tolerance: {tolerance_px}px"
+                )
+                result = (
+                    expected_width_px - tolerance_px
+                    <= actual_width_px
+                    <= expected_width_px + tolerance_px
+                )
+            else:
+                expected_height_px = parent_height_px * con_layout.percent // 100
+                run_command_on(con, f"resize set height {expected_height_px} px")
+                actual_height_px = con.rect.height
+                tolerance_px = expected_height_px * RESIZE_TOLERANCE_PERCENT // 100
+                logger.debug(
+                    f"Expected height: {expected_height_px}px, actual height: {actual_height_px}px, "
+                    + f"tolerance: {tolerance_px}px"
+                )
+                result = (
+                    expected_height_px - tolerance_px
+                    <= actual_height_px
+                    <= expected_height_px + tolerance_px
+                )
+
+        # Resize children once the parent container has been resized.
+        if result and isinstance(con_layout, ContainerConfig):
+            resize_children(con_layout)
+
+        return result
+
+    tree = connection.get_tree()
+    resize_children(workspace_layout)
+
+
+def check_layout(
+    connection: Connection,
+    workspace_layout: WorkspaceLayout,
+) -> bool:
+    """Checks if the current layout matches the given workspace layout.
+
+    Parameters:
+        connection: A connection to sway.
+        workspace_layout: The layout to check against.
+
+    Returns:
+        `True` if the current layout matches the given workspace layout, `False` otherwise.
+    """
+
+    def check_container_layout(
+        container_layout: ApplicationLaunchConfig | ContainerConfig,
+        parent_width_px: int,
+        parent_height_px: int,
+        parent_layout: Literal["splith", "splitv", "other"],
+    ) -> bool:
+        assert (
+            container_layout._con_id is not None
+        ), "The con_id of the container layout should have been set before calling this function."
+
+        con = tree.find_by_id(container_layout._con_id)
+
+        result = True
+
+        if container_layout.percent is not None:
+            assert parent_layout != "other", (
+                "Percentages are only supported for horizontal and vertical splits, not for other layouts."
+                + "This should have been enforced by the configuration models."
+            )
+            if parent_layout == "splith":
+                # We assume that the decoration is always at the top.
+                assert con.rect.width == con.deco_rect.width or con.deco_rect.width == 0
+                actual_percent = con.rect.width * 100 // parent_width_px
+                expected_width_px = parent_width_px * container_layout.percent // 100
+                logger.debug(
+                    f"Expected width: {expected_width_px}px, actual width: {con.rect.width}px"
+                )
+            else:
+                actual_percent = (
+                    (con.rect.height + con.deco_rect.height) * 100 // parent_height_px
+                )
+                expected_height_px = parent_height_px * container_layout.percent // 100
+                logger.debug(
+                    f"Expected height: {expected_height_px}px, actual height: {con.rect.height}px"
+                )
+
+            if (
+                container_layout.percent - RESIZE_TOLERANCE_PERCENT
+                <= actual_percent
+                <= container_layout.percent + RESIZE_TOLERANCE_PERCENT
+            ):
+                logger.debug(
+                    f"Container layout for {get_con_description(con)} matches the expected percentage: "
+                    + f"{actual_percent}% == {container_layout.percent}%"
+                )
+                result = True
+            else:
+                logger.error(
+                    f"Container layout for {get_con_description(con)} does not match the expected "
+                    + f"percentage: {actual_percent}% != {container_layout.percent}%"
+                )
+                result = False
+
+        if isinstance(container_layout, ContainerConfig):
+            # Get the container dimensions
+            con_width_px, con_height_px = _get_container_size_excluding_gaps(con)
+            if con.layout in ["splith", "splitv"]:
+                con_layout = con.layout
+            else:
+                con_layout = "other"
+
+            # Check all children, even if some do not match.
+            for child in container_layout.children:
+                if not check_container_layout(
+                    child, con_width_px, con_height_px, con_layout
+                ):
+                    result = False
+
+        return result
+
+    tree = connection.get_tree()
+    assert (
+        workspace_layout._con_id is not None
+    ), "The con_id of the workspace layout should have been set before calling this function."
+    workspace_con = tree.find_by_id(workspace_layout._con_id)
+    if not workspace_con:
+        logger.error(
+            f"Workspace with con_id {workspace_layout._con_id} not found in the tree."
+        )
+        return False
+
+    if workspace_con.layout in ["splith", "splitv"]:
+        layout = workspace_con.layout
+    else:
+        layout = "other"
+    width_px, height_px = _get_container_size_excluding_gaps(workspace_con)
+
+    # Always check all containers in the workspace to show an exhaustive error message.
+    result = True
+    for child in workspace_layout.children:
+        if not check_container_layout(child, width_px, height_px, layout):
+            result = False
+    return result
+
+
+def _find_con(
+    tree: Con, container: WorkspaceLayout | ContainerConfig | ApplicationLaunchConfig
+) -> Con:
+    con_id = container._con_id
+    assert con_id is not None, (
+        f"Application {container} has no con_id set. "
+        + "This is required for the layout creation."
+    )
+    result = tree.find_by_id(con_id)
+    if result is None:
+        raise RuntimeError(f"Container for application with con ID {con_id} not found")
+    else:
+        return result
+
+
+def _get_container_size_excluding_gaps(con: Con) -> tuple[int, int]:
+    # For windows, we use the rect and deco rect.
+    # rect does not include the decoration, i.e. title bar.
+    # For containers, we sum up the children where necessary to exclude
+    # gaps between windows in the result.
+    # We assume that the decoration is always at the top.
+
+    if con.layout == "splith":
+        width = sum(_get_container_size_excluding_gaps(child)[0] for child in con.nodes)
+    else:
+        assert con.rect.width == con.deco_rect.width or con.deco_rect.width == 0
+        width = con.rect.width
+
+    if con.layout == "splitv":
+        height = sum(
+            _get_container_size_excluding_gaps(child)[1] for child in con.nodes
+        )
+    else:
+        height = con.rect.height + con.deco_rect.height
+
+    return width, height

--- a/src/sway_out/matching.py
+++ b/src/sway_out/matching.py
@@ -6,7 +6,7 @@ from collections.abc import Generator
 
 from i3ipc import Con, Connection
 
-from .layout_files import ApplicationLaunchConfig, WindowMatchExpression
+from .layout_files import WindowMatchExpression
 
 logger = logging.getLogger(__name__)
 

--- a/src/sway_out/notifications.py
+++ b/src/sway_out/notifications.py
@@ -14,6 +14,7 @@ class ProgressNotification:
         self.summary = stage
         self.text = text
         self.notification: Notify.Notification = None
+        self.successful = True
 
     def start(self):
         """Start the progress indicator.
@@ -21,7 +22,7 @@ class ProgressNotification:
         Without calling this method first, `self.update()` is a no-op.
         """
 
-        self.notification = Notify.Notification.new(self.text, f"{self.text} ...")
+        self.notification = Notify.Notification.new(self.summary, f"{self.text} ...")
         self.notification.set_timeout(Notify.EXPIRES_NEVER)
         self.notification.show()
 
@@ -42,8 +43,11 @@ class ProgressNotification:
         """
 
         if self.notification is not None:
-            self.notification.update(self.summary, "Completed successfully.")
-            self.notification.set_timeout(Notify.EXPIRES_DEFAULT)
+            if self.successful:
+                self.notification.update(self.summary, "Completed successfully.")
+            else:
+                self.notification.update(self.summary, "Completed with errors.")
+
             self.notification.show()
 
     def error(self, error_message: str):
@@ -55,7 +59,7 @@ class ProgressNotification:
         if self.notification is not None:
             self.notification.update(
                 self.summary,
-                f"{self.text} - Error: {error_message}",
+                (f"{self.text} - " if self.text else "") + f"Error: {error_message}",
             )
             self.notification.set_urgency(Notify.Urgency.CRITICAL)
             self.notification.set_timeout(Notify.EXPIRES_DEFAULT)

--- a/src/sway_out/utils.py
+++ b/src/sway_out/utils.py
@@ -1,0 +1,33 @@
+"""Small utility function."""
+
+from i3ipc import Con
+
+
+def is_window(con: Con) -> bool:
+    """Check if a container is a window.
+
+    Parameters:
+        con: The container to check.
+
+    Returns:
+        `True` if the container is a window, `False` otherwise.
+    """
+    return con.pid is not None
+
+
+def get_con_description(con: Con) -> str:
+    """Get a human-readable description of a container.
+
+    Parameters:
+        con: The container to describe.
+
+    Returns:
+        A string describing the container.
+    """
+
+    if is_window(con):
+        return f"{con.name} (PID: {con.pid})"
+    elif con.type == "workspace":
+        return f"{con.name} (ID: {con.id})"
+    else:
+        return f"{con.name} (ID: {con.id})"


### PR DESCRIPTION
Introduce an option in layout files to specify the size of child containers in split layouts. Check if the sizes match the configuration after applying the size configuration.

Closes #25.