### PR TITLE
feat: map existing windows before applying the layout

### DIFF
--- a/src/sway_out/connection.py
+++ b/src/sway_out/connection.py
@@ -94,11 +94,7 @@ def find_con_by_id(connection: Connection, con_id: int) -> Con:
         containers at once.
     """
 
-    tree = connection.get_tree()
-    result = tree.find_by_id(con_id)
-    if not result:
-        raise RuntimeError(f"Container with con_id {con_id} not found in tree")
-    return result
+    return find_cons_by_id(connection, con_id)[0]
 
 
 def find_cons_by_id(connection: Connection, *con_ids: int) -> tuple[Con, ...]:
@@ -119,8 +115,8 @@ def find_cons_by_id(connection: Connection, *con_ids: int) -> tuple[Con, ...]:
     Raises:
         RuntimeError: If a container with a given con_id is not found in the tree.
     """
-    tree = connection.get_tree()
-    result = tuple(tree.find_by_id(con_id) for con_id in con_ids)
+
+    result = find_cons_by_id_if_exists(connection, *con_ids)
     missing_ids = [con_id for con_id, con in zip(con_ids, result) if con is None]
     if missing_ids:
         raise RuntimeError(
@@ -128,3 +124,25 @@ def find_cons_by_id(connection: Connection, *con_ids: int) -> tuple[Con, ...]:
         )
     assert None not in result
     return result
+
+
+def find_cons_by_id_if_exists(
+    connection: Connection, *con_ids: int
+) -> tuple[Con | None, ...]:
+    """Finds all containers with the given con_ids if they exist.
+    This function is similar to `find_cons_by_id`, but it does not raise an error
+    if a container with a given con_id is not found. Instead, it returns None for
+    those containers.
+
+    Arguments:
+        connection: The Sway connection to use.
+        con_ids: The con_ids of the containers to find.
+
+    Returns:
+        A list of containers with the given con_ids or `None` if the respective
+        con_id does not match that of an existing container. The order of the
+        list matches the order of the con_ids.
+    """
+
+    tree = connection.get_tree()
+    return tuple(tree.find_by_id(con_id) for con_id in con_ids)

--- a/src/sway_out/main.py
+++ b/src/sway_out/main.py
@@ -8,9 +8,15 @@ import pydantic
 import yaml
 from i3ipc import Connection
 
-from .applications import launch_applications_from_layout
+from .applications import launch_applications_from_layout, match_existing_windows
 from .connection import find_con_by_id, run_command, run_command_on
-from .layout import check_layout, create_layout, find_leftover_windows, resize_layout
+from .layout import (
+    check_layout,
+    create_layout,
+    dissolve_layout,
+    find_leftover_windows,
+    resize_layout,
+)
 from .layout_files import (
     find_focused_element_in_layout,
     load_layout_configuration,
@@ -75,6 +81,10 @@ def main_apply(ctx: click.Context, layout_file):
             workspace_con = find_current_workspace(connection)
             workspace_layout._con_id = workspace_con.id
             assert workspace_con is not None, "No current workspace found?"
+            logging.debug("Matching existing windows on workspace: %s", workspace_name)
+            match_existing_windows(workspace_con, workspace_layout)
+            logging.debug("Dissolving layout for workspace: %s", workspace_name)
+            dissolve_layout(connection, workspace_con)
             logger.info("Applying layout for workspace: %s", workspace_name)
             launch_applications_from_layout(connection, workspace_layout)
             create_layout(connection, workspace_layout)


### PR DESCRIPTION
Map existing windows to the layout definition before applying the layout.  This prevents application from being again if a matching window already exists on the workspace.

BREAKING CHANGE: The behavior on non-empty workspaces has changed.

Closes #8.