### PR TITLE
build: go back to the default conventional commit commitizen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ src_paths = ["src", "tests"]
 skip_gitignore = true
 
 [tool.commitizen]
-name = "cz_extended_conventional"
 tag_format = "v$major.$minor.$patch$prerelease"
 version_scheme = "pep440"
 version_provider = "uv"


### PR DESCRIPTION
Because maintining my own is too much of a hassle for now unless it gains more features.